### PR TITLE
add backlink to main repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ classifiers = [
 ]
 dependencies = ["aiohttp>=3.11.0"]
 
+[project.urls]
+Repository = "https://github.com/music-assistant/SoundcloudPy"
+
 [project.optional-dependencies]
 
 test = [


### PR DESCRIPTION
### Problem

Discovery of the underlying package source code was difficult to find from the [official pypi page](https://pypi.org/project/soundcloudpy/) of this module.

Additionally, it was undiscoverable from a Google search `soundcloudpy github` from my location.

### Solution

Add metadata to the Python package bundling to make discoverability a little easier for humans and crawlers alike.

Used https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls as a reference.